### PR TITLE
Condiciones duplicadas en metodo setClientCerts

### DIFF
--- a/fire-client-dotnet/FIRe/ConnectionManager.cs
+++ b/fire-client-dotnet/FIRe/ConnectionManager.cs
@@ -143,7 +143,7 @@ namespace FIRe
                 log.TraceData(TraceEventType.Warning, 1, "No se ha encontrado un certificado cliente SSL configurado en el registro: " + e.ToString());
             }
 
-            if (!string.IsNullOrEmpty(sslClientPkcs12) && !string.IsNullOrEmpty(sslClientPkcs12))
+            if (!string.IsNullOrEmpty(sslClientPkcs12) && !string.IsNullOrEmpty(sslClientPass))
             {
                 try
                 {

--- a/fire-client-dotnet/FIRe/FIRe/FireClient.cs
+++ b/fire-client-dotnet/FIRe/FIRe/FireClient.cs
@@ -776,6 +776,9 @@ namespace FIRe
         /// <exception cref="InvalidTransactionException">Cuando se intenta operar sobre una transaccion inexistente o ya caducada.</exception>
         private static byte[] getResponseToPostPetition(string url, string urlParameters, Dictionary<String, String> config)
         {
+            HttpWebResponse response = null;
+            Stream dataStream = null;
+            MemoryStream ms = null;
             try
             {
                 // generamos la respuesta del servidor
@@ -785,10 +788,6 @@ namespace FIRe
                 MemoryStream ms = new MemoryStream();
                 dataStream.CopyTo(ms);
                 byte[] bytes = ms.ToArray();
-                // Cerramos los streams
-                response.Close();
-                ms.Close();
-                dataStream.Close();
 
                 return bytes;
             }
@@ -838,6 +837,13 @@ namespace FIRe
             }
             catch (Exception e) {
                 throw new HttpOperationException(e.Message, e);
+            }
+            finally
+            {
+                // Cerramos los streams
+                if (ms != null) { ms.Close(); }
+                if (dataStream != null) { dataStream.Close(); }
+                if (response != null) response.Close();
             }
         }
 


### PR DESCRIPTION
En el método setClientCerts la condición que verifica la validez de los parámetros estaba duplicada, se corrige para incluir los dos parámetros sslClientPkcs12 y sslClientPass.