### PR TITLE
Mostrar en el simulador los nombres y títulos de los documentos enviados a firmar.

### DIFF
--- a/clavefirma-test-services/src/main/java/es/gob/clavefirma/test/services/TestHelper.java
+++ b/clavefirma-test-services/src/main/java/es/gob/clavefirma/test/services/TestHelper.java
@@ -61,12 +61,14 @@ class TestHelper {
 	private static final String REDIRECT_URL_ID_TAG = "$$TID$$"; //$NON-NLS-1$
 	private static final String REDIRECT_URL_OK_TAG = "$$ROK$$"; //$NON-NLS-1$
 	private static final String REDIRECT_URL_KO_TAG = "$$RKO$$"; //$NON-NLS-1$
+	private static final String REDIRECT_URL_INFODOCUMENTOS_TAG = "$$INFODOCUMENTOS$"; //$NON-NLS-1$
 	private static final String REDIRECT_ID = "$$ID$$"; //$NON-NLS-1$
 
 	private static final String URL_SIGN_PARAMETERS_TEMPLATE = "test_pages/TestAuth.jsp?transactionid=" + REDIRECT_URL_ID_TAG //$NON-NLS-1$
 			+ "&redirectko=" + REDIRECT_URL_KO_TAG //$NON-NLS-1$
 			+ "&redirectok=" + REDIRECT_URL_OK_TAG //$NON-NLS-1$
-			+ "&id=" + REDIRECT_ID; //$NON-NLS-1$
+			+ "&id=" + REDIRECT_ID //$NON-NLS-1$
+			+ "&infoDocumentos=" + REDIRECT_URL_INFODOCUMENTOS_TAG; //$NON-NLS-1$
 
 	private static final String URL_CERT_PARAMETERS_TEMPLATE = "test_pages/TestCert.jsp?transactionid=" + REDIRECT_URL_ID_TAG //$NON-NLS-1$
 			+ "&redirectko=" + REDIRECT_URL_KO_TAG //$NON-NLS-1$
@@ -370,20 +372,22 @@ class TestHelper {
 	}
 
 	@SuppressWarnings("deprecation")
-	static String getSignRedirectionUrl(final String subjectId, final String transactionId, final String okUrlB64, final String errorUrlB64) {
+	static String getSignRedirectionUrl(final String subjectId, final String transactionId, final String okUrlB64, final String errorUrlB64, final String infoDocumentosB64) {
 		try {
 			return urlTemplateSign
 					.replace(REDIRECT_URL_ID_TAG, transactionId)
 					.replace(REDIRECT_URL_OK_TAG, okUrlB64)
 					.replace(REDIRECT_URL_KO_TAG, errorUrlB64)
-					.replace(REDIRECT_ID, URLEncoder.encode(subjectId, DEFAULT_ENCODING));
+					.replace(REDIRECT_ID, URLEncoder.encode(subjectId, DEFAULT_ENCODING))
+					.replace(REDIRECT_URL_INFODOCUMENTOS_TAG, infoDocumentosB64);
 		} catch (final UnsupportedEncodingException e) {
 			LOGGER.warning("No se soporta el encoding proporcionado para codificar la URL, se usara el por defecto: " + e); //$NON-NLS-1$
 			return urlTemplateSign
 					.replace(REDIRECT_URL_ID_TAG, transactionId)
 					.replace(REDIRECT_URL_OK_TAG, okUrlB64)
 					.replace(REDIRECT_URL_KO_TAG, errorUrlB64)
-					.replace(REDIRECT_ID, URLEncoder.encode(subjectId));
+					.replace(REDIRECT_ID, URLEncoder.encode(subjectId))
+					.replace(REDIRECT_URL_INFODOCUMENTOS_TAG, infoDocumentosB64);
 		}
 	}
 

--- a/clavefirma-test-services/src/main/java/es/gob/clavefirma/test/services/TestLoadDataService.java
+++ b/clavefirma-test-services/src/main/java/es/gob/clavefirma/test/services/TestLoadDataService.java
@@ -58,6 +58,9 @@ public class TestLoadDataService extends HttpServlet {
 	/** Clave para indicar que el certificado de usuario no existe y se debe cargar el "nuevo" certificado. */
 	public static final String KEY_NEWCERT = "newcert"; //$NON-NLS-1$
 
+	/** Clave para indicar la información de los documentos */
+	public static final String KEY_INFODOCUMENTOS = "infoDocumentos"; //$NON-NLS-1$
+
 
 	/**
 	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
@@ -71,6 +74,7 @@ public class TestLoadDataService extends HttpServlet {
 		final String triDataB64UrlSafe = request.getParameter(KEY_TRIPHASEDATA);
 		final String redirectOkUrlB64UrlSafe = request.getParameter(KEY_REDIRECT_OK);
 		final String redirectErrorUrlB64UrlSafe = request.getParameter(KEY_REDIRECT_ERROR);
+		final String infoDocumentosB64 = request.getParameter(KEY_INFODOCUMENTOS);
 
 		try {
 			TestHelper.doSubjectExist(subjectId);
@@ -99,7 +103,7 @@ public class TestLoadDataService extends HttpServlet {
 		p.store(fos, ""); //$NON-NLS-1$
 		fos.close();
 
-		final String redirectUrl = TestHelper.getSignRedirectionUrl(subjectId, transactionId, redirectOkUrlB64UrlSafe, redirectErrorUrlB64UrlSafe);
+		String redirectUrl = TestHelper.getSignRedirectionUrl(subjectId, transactionId, redirectOkUrlB64UrlSafe, redirectErrorUrlB64UrlSafe, infoDocumentosB64);
 
 		final LoadResult result = new LoadResult(
 			transactionId,

--- a/clavefirma-test-services/src/main/webapp/test_pages/TestAuth.jsp
+++ b/clavefirma-test-services/src/main/webapp/test_pages/TestAuth.jsp
@@ -4,6 +4,25 @@
 <%@page language="java" contentType="text/html; charset=ISO-8859-1" pageEncoding="ISO-8859-1"%>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+ <%
+ 	String infoDocumentos = request.getParameter("infoDocumentos");
+	
+ 	String[] info = new String[0];
+ 	if (infoDocumentos!=null && !"".equals(infoDocumentos)){
+ 		infoDocumentos = new String(Base64.decode(infoDocumentos, true),"UTF-8");
+ 		info = infoDocumentos.split(",");
+ 	}
+	
+	boolean hayInfo = false;
+	for (int i=0; i<info.length; i++){
+		if (info[i]!=null && !info[i].equals("") && !info[i].equals(" ")){
+			hayInfo = true;
+		}
+	}
+ %>
+ 
+ 
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
@@ -68,14 +87,59 @@
 
  <form method="post" action="<%= request.getContextPath() %>/TestServiceAuthServlet" id="pinAndSFDA">
 
-<section class="tmpl_2_cols">	
-	<h1>Firma</h1> 
-	<div class="centro_tituloCabecera">
-	<p class="margen_der">Esta es una p&aacute;gina de prueba para simular el servicio de firma.</p>&nbsp;&nbsp;						   								<p class="margen_der">Para firmar, a continuación introduce tu contraseña.</p>
-	</div>
-</section>
+ <% if (!hayInfo) { %>
+	<section class="tmpl_2_cols">	
+<% } else { %>
+	<section class="tmpl_3_cols">
+<% } %>
+		<h1>Firma</h1> 
+		<div class="centro_tituloCabecera">
+		<p class="margen_der">Esta es una p&aacute;gina de prueba para simular el servicio de firma.</p>&nbsp;&nbsp;						   								<p class="margen_der">Para firmar, a continuación introduce tu contraseña.</p>
+		</div>
+	</section>
 
-<section class="tmpl_2_cols">
+	
+ <% if (hayInfo) { %>
+
+	<section class="tmpl_4_cols">
+	<fieldset>
+		<div class="row" id="pasarela-content-row">
+		<p class="tituloFirma">
+			<label class="grisoscuro" for="owner">Documentos a firmar </label>
+		</p>
+		<table id="documents-table">
+		<thead class="fixedHeaderTable">
+		<tr>
+			<th>Id. Documento</th><th>Título </th>
+		</tr>
+		</thead>
+		<tbody>
+			<%
+				for (int i=0; i<info.length; i=i+2){
+			%>
+				<tr>
+					<td><%= info[i] %></td>
+					<td><%= info[i+1] %></td>
+				</tr>
+			<%
+				}
+			%>
+		</tbody>
+		</table>
+		</div>
+	</fieldset>
+	</section>
+ 
+	
+<% } %>
+	
+	
+	
+<% if (!hayInfo) { %>
+	<section class="tmpl_2_cols">
+<% } else { %>
+	<section class="tmpl_5_cols">
+<% } %>
 <fieldset>
 	 <p>
 	 <label class="grisoscuro" for="owner">USUARIO FIRMANTE</label>&nbsp;&nbsp;								<%= request.getParameter("id") %></p>

--- a/clavefirma-test-services/src/main/webapp/test_pages/TestAuth_files/IdP.css
+++ b/clavefirma-test-services/src/main/webapp/test_pages/TestAuth_files/IdP.css
@@ -6,6 +6,14 @@ body {
   color: #51504f;
 }
 
+.tituloFirma {
+  white-space: pre-line;
+  margin-top: -5px;
+  margin-left: 3px;
+  margin-right: 19px;
+	
+}
+
 FIELDSET {
 	border: 0;
 	margin: 0 0 10px;
@@ -54,6 +62,53 @@ FIELDSET {
 	margin-left: 2%;
 	margin-right: 2%;
 }
+
+
+@media (min-width: 620px) {
+	.tmpl_4_cols {
+		position: relative;
+		float: left;
+		width: 20%;
+		margin-left: 2%;
+		margin-right: 2%;
+	}
+}
+
+
+@media (max-width: 520px) {
+	.tmpl_4_cols {
+		position: relative;
+		float: left;
+		width: 50%;
+		margin-left: 2%;
+		margin-right: 2%;
+	}
+}
+
+
+
+@media (min-width: 620px) {
+	.tmpl_5_cols {
+	position: relative;
+		float: left;
+		width: 33%;
+		margin-left: 2%;
+		margin-right: 2%;
+	}
+}
+
+
+@media (max-width: 520px) {
+	.tmpl_5_cols {
+	position: relative;
+		float: left;
+		width: 50%;
+		margin-left: 2%;
+		margin-right: 2%;
+	}
+}
+
+
 /*------------------------------ FOOTER ---------------------------------------*/
 
 footer { position: relative; width: 100%; color: #fff; background: #707070; border-top: 3px solid #FF6600; margin-top: 2em;}

--- a/fire-signature-common-libraries/pom.xml
+++ b/fire-signature-common-libraries/pom.xml
@@ -29,6 +29,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>es.gob.afirma</groupId>
+			<artifactId>afirma-crypto-core-pkcs7-tsp</artifactId>
+			<version>1.6</version>
+		</dependency>
+
+		<dependency>
 			<groupId>javax.json</groupId>
 			<artifactId>javax.json-api</artifactId>
 			<version>1.0</version>
@@ -43,6 +49,12 @@
 		<dependency>
 			<groupId>com.openlandsw.rss</groupId>
     		<artifactId>gateway-api</artifactId>
+    		<version>2.4.05</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.openlandsw.rss</groupId>
+    		<artifactId>gateway-api-comun</artifactId>
     		<version>2.4.05</version>
 		</dependency>
 

--- a/fire-signature-common-libraries/src/main/java/es/gob/fire/signature/connector/test/TestConnector.java
+++ b/fire-signature-common-libraries/src/main/java/es/gob/fire/signature/connector/test/TestConnector.java
@@ -33,7 +33,9 @@ import javax.json.JsonReader;
 import es.gob.afirma.core.misc.Base64;
 import es.gob.afirma.core.misc.http.HttpError;
 import es.gob.afirma.core.signers.TriphaseData;
+import es.gob.afirma.core.signers.TriphaseData.TriSign;
 import es.gob.fire.signature.ConfigManager;
+import es.gob.fire.signature.DocInfo;
 import es.gob.fire.signature.GenerateCertificateResult;
 import es.gob.fire.signature.LoadResult;
 import es.gob.fire.signature.connector.CertificateBlockedException;
@@ -214,6 +216,23 @@ public class TestConnector implements FIReConnector {
 			throw new FIReCertificateException("Error en la codificacion del certificado", e); //$NON-NLS-1$
 		}
 
+		
+		// Enviamos la información de los documentos separando cada campo por una coma. 
+		// Si algún campo no se indica, enviamos un " " para que se incluya el hueco entre las comas.
+		String infoDocumentos = "";
+		for (TriSign triSign : td.getTriSigns()) {
+			DocInfo docInfo = DocInfo.extractDocInfo(triSign);
+			String name = docInfo.getName();
+			if (name == null || name.equals("")) {
+				name = " ";
+			}
+			String title = docInfo.getTitle();
+			if (title == null || title.equals("")) {
+				title = " ";
+			}
+			infoDocumentos += name + "," + title + ",";
+		}
+		
 		final String urlBase = this.testUrlBase + "TestLoadDataService"; //$NON-NLS-1$
 		final StringBuilder urlParameters = new StringBuilder()
 		.append("subjectid=").append(subjectId) //$NON-NLS-1$
@@ -221,7 +240,8 @@ public class TestConnector implements FIReConnector {
 		.append("&certificate=").append(Base64.encode(certEncoded, true)) //$NON-NLS-1$
 		.append("&triphasedata=").append(Base64.encode(td.toString().getBytes(DEFAULT_ENCODING), true)) //$NON-NLS-1$
 		.append("&urlok=").append(Base64.encode(this.redirectOkUrl.getBytes(DEFAULT_ENCODING), true)) //$NON-NLS-1$
-		.append("&urlerror=").append(Base64.encode(this.redirectErrorUrl.getBytes(DEFAULT_ENCODING), true)); //$NON-NLS-1$
+		.append("&urlerror=").append(Base64.encode(this.redirectErrorUrl.getBytes(DEFAULT_ENCODING), true)) //$NON-NLS-1$
+		.append("&infoDocumentos=").append(Base64.encode(infoDocumentos.getBytes(DEFAULT_ENCODING), true)); //$NON-NLS-1$
 
 		byte[] response;
 		try {


### PR DESCRIPTION
Se modifica el conector del componente central con el simulador para que también envíe los datos de los documentos.
Se modifica el simulador para que muestre los datos de los documentos.