### PR TITLE
Se modifica el guardado de sesiones en disco.

### DIFF
--- a/fire-signature-common-libraries/src/main/java/es/gob/fire/signature/DocInfo.java
+++ b/fire-signature-common-libraries/src/main/java/es/gob/fire/signature/DocInfo.java
@@ -9,6 +9,7 @@
  */
 package es.gob.fire.signature;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import es.gob.afirma.core.signers.TriphaseData.TriSign;
@@ -16,7 +17,9 @@ import es.gob.afirma.core.signers.TriphaseData.TriSign;
 /**
  * Clase para almacenar informaci&oacute;n del documento firmado.
  */
-public class DocInfo {
+public class DocInfo implements Serializable{
+
+	private static final long serialVersionUID = 1L;
 
 	private static final String PROPERTY_DOC_TITLE = "docTitle"; //$NON-NLS-1$
 

--- a/fire-signature/src/main/java/es/gob/fire/server/services/internal/SessionCollector.java
+++ b/fire-signature/src/main/java/es/gob/fire/server/services/internal/SessionCollector.java
@@ -232,17 +232,17 @@ public final class SessionCollector {
 
 		if (!onlyLoaded) {
 
-			// Comprobamos si la transaccion esta en memoria
+			// Comprobamos si la transaccion esta en almacenamiento persistente (para multiples nodos)
 			if (fireSession == null) {
-				fireSession = findSessionFromServerMemory(trId);
+				fireSession = findSessionFromSharedMemory(trId, session);
 				if (fireSession != null && session != null) {
 					fireSession.copySessionAttributes(session);
 				}
 			}
 
-			// Comprobamos si la transaccion esta en almacenamiento persistente (para multiples nodos)
+			// Comprobamos si la transaccion esta en memoria
 			if (fireSession == null) {
-				fireSession = findSessionFromSharedMemory(trId, session);
+				fireSession = findSessionFromServerMemory(trId);
 				if (fireSession != null && session != null) {
 					fireSession.copySessionAttributes(session);
 				}
@@ -334,7 +334,7 @@ public final class SessionCollector {
 			if (fireSession != null) {
 				if (fireSession.isExpired()) {
 					fireSession.invalidate();
-					dao.removeSession(id);
+					removeSession(id);
 					return null;
 				}
 			}


### PR DESCRIPTION
Las sesiones se deben buscar primero en el almacenamiento persistente. Si una sesión ha sido modificada en un servidor, no se modifica en la memoria de los demás servidores.

Por ejemplo, tenemos dos servidores, S1 Y S2, con el componente central. La aplicación, APP, llama a uno o a otro indistintamente.

APP llama a S1 para crear un lote. Se crea el lote, y se guarda la sesión en la memoria de S1 y en el disco.
APP llama a S2 para añadir un documento al lote. S2 no tiene la sesión en memoria, la busca en el disco, añade el documento y guarda la sesión en su memoria y en el disco.
APP llama a S1 para firmar el lote. S1 tiene la sesión en su memoria ya que la guardó en el primer paso, así que no la busca en el disco. Esta sesión no tiene el documento añadido, al intentar realizar la firma se genera un error (es.gob.fire.server.services.internal.PreSignService.service No se han agregado documentos al lote).

